### PR TITLE
Update index.rst

### DIFF
--- a/install/core/index.rst
+++ b/install/core/index.rst
@@ -61,6 +61,9 @@ First, we are going to install all the **system packages** needed for the GeoNod
 
   # Install VIM
   sudo apt install -y vim
+  
+  # Install Packages for Virtual environment management
+  sudo apt install -y virtualenv virtualenvwrapper
 
   sudo apt update -y
   sudo apt upgrade -y


### PR DESCRIPTION
Instructions were missing steps to install packages for Virtual environment management
  `sudo apt install -y virtualenv virtualenvwrapper`
Without this the core instalation fails at ~$ source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
with: -bash: /usr/share/virtualenvwrapper/virtualenvwrapper.sh: No such file or directory