### PR TITLE
[Issue GeoNode/geonode#6079] Reference spatial data stores for Django database

### DIFF
--- a/advanced/contrib/index.rst
+++ b/advanced/contrib/index.rst
@@ -204,7 +204,7 @@ and the ``/opt/geonode/my-geonode/.env`` is something similar to the following o
 
     DEBUG=False
     DJANGO_ALLOWED_HOSTS=<geonode_public_host>,localhost,127.0.0.1
-    DJANGO_DATABASE_URL=postgresql://my_geonode:**********@localhost:5432/my_geonode_db
+    DJANGO_DATABASE_URL=postgis://my_geonode:**********@localhost:5432/my_geonode_db
     DEFAULT_BACKEND_UPLOADER=geonode.importer
     DEFAULT_FROM_EMAIL=geonode@example.org
     DJANGO_EMAIL_HOST=smtp.example.org
@@ -470,13 +470,13 @@ invocation polling (so the time range on which data should be aggregated).
 
 Other settings come with a default value:
 
-* **Db path** --> the local SQLite database to cache events between emitting and transmission to the Logstash server (log events are cached even across process restarts and crashes);
+* **Db path** --> the local Spatialite database to cache events between emitting and transmission to the Logstash server (log events are cached even across process restarts and crashes);
 * **Socket timeout** --> timeout in seconds for TCP connections;
 * **Queue check interval** --> interval in seconds to check the internal queue for new messages to be cached in the database;
 * **Queue events flush interval** --> interval in seconds to send cached events from the database to Logstash;
 * **Queue events flush count** --> count of cached events to send from the database to Logstash;
 * **Queue events batch size** --> maximum number of events to be sent to Logstash in one batch;
-* **Logstash db timeout** --> timeout in seconds to 'connect' the SQLite database.
+* **Logstash db timeout** --> timeout in seconds to 'connect' the Spatialite database.
 
 To better understand what these variables mean, it is recommended to read the `python-logstash-async options for the asynchronous processing and formatting <https://python-logstash-async.readthedocs.io/en/stable/config.html#options-for-the-asynchronous-processing-and-formatting>`_.
 

--- a/devel/installation/index.rst
+++ b/devel/installation/index.rst
@@ -33,7 +33,7 @@ The steps to be followed are:
 Install GeoNode-Core for development
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-GeoNode-Core installation is considered the most basic form of GeoNode. It doesn't require any external server to be installed and it can run locally against a file-system based SQLite database.
+GeoNode-Core installation is considered the most basic form of GeoNode. It doesn't require any external server to be installed and it can run locally against a file-system based Spatialite database.
 
 Installation steps
 ..................

--- a/install/advanced/core/index.rst
+++ b/install/advanced/core/index.rst
@@ -94,7 +94,7 @@ GeoNode Installation
 
 This is the most basic installation of GeoNode. It won't use any external server like ``Apache Tomcat``, ``PostgreSQL`` or ``HTTPD``.
 
-It will run locally against a file-system based ``SQLite`` database.
+It will run locally against a file-system based ``Spatialite`` database.
 
 
 First of all we need to prepare a new Python Virtual Environment
@@ -153,7 +153,7 @@ Run GeoNode for the first time in DEBUG Mode
 
   Be sure you have successfully completed all the steps of the section :ref:`install_dep`.
 
-This command will run both GeoNode and GeoServer locally after having prepared the SQLite database. The server will start in ``DEBUG`` (or ``DEVELOPMENT``) mode, and it will start the following services:
+This command will run both GeoNode and GeoServer locally after having prepared the Spatialite database. The server will start in ``DEBUG`` (or ``DEVELOPMENT``) mode, and it will start the following services:
 
 #. GeoNode on ``http://localhost:8000/``
 #. GeoServer on ``http://localhost:8080/geoserver/``
@@ -162,7 +162,7 @@ This modality is beneficial to debug issues and/or develop new features, but it 
 
 .. code-block:: shell
 
-  # Prepare the GeoNode SQLite database (the first time only)
+  # Prepare the GeoNode Spatialite database (the first time only)
   paver setup
   paver sync
 
@@ -242,6 +242,7 @@ Next let's create PostGIS extensions
 
 .. code-block:: shell
 
+  sudo -u postgres psql -d geonode -c 'CREATE EXTENSION postgis;'
   sudo -u postgres psql -d geonode_data -c 'CREATE EXTENSION postgis;'
   sudo -u postgres psql -d geonode_data -c 'GRANT ALL ON geometry_columns TO PUBLIC;'
   sudo -u postgres psql -d geonode_data -c 'GRANT ALL ON spatial_ref_sys TO PUBLIC;'
@@ -1072,7 +1073,7 @@ invoke==1.4.1
 
 .. code-block:: shell
 
-    # Prepare the GeoNode SQLite database (the first time only)
+    # Prepare the GeoNode Spatialite database (the first time only)
     paver setup
     paver sync
     python manage.py runserver

--- a/install/advanced/project/index.rst
+++ b/install/advanced/project/index.rst
@@ -160,7 +160,7 @@ Run GeoNode Project for the first time in DEBUG Mode
 
   Be sure you have successfully completed all the steps of the section :ref:`install_dep_proj`.
 
-This command will run both GeoNode and GeoServer locally after having prepared the SQLite database. The server will start in ``DEBUG`` (or ``DEVELOPMENT``) mode, and it will start the following services:
+This command will run both GeoNode and GeoServer locally after having prepared the Spatialite database. The server will start in ``DEBUG`` (or ``DEVELOPMENT``) mode, and it will start the following services:
 
 #. GeoNode on ``http://localhost:8000/``
 #. GeoServer on ``http://localhost:8080/geoserver/``
@@ -169,7 +169,7 @@ This modality is beneficial to debug issues and/or develop new features, but it 
 
 .. code-block:: shell
 
-  # Prepare the GeoNode SQLite database (the first time only)
+  # Prepare the GeoNode Spatialite database (the first time only)
   ./paver_dev.sh setup
   ./paver_dev.sh sync
 

--- a/install/basic/index.rst
+++ b/install/basic/index.rst
@@ -230,9 +230,9 @@ In the case you would like to deploy to, let's say, :guilabel:`https://my_geonod
     +GEONODE_GEODATABASE=my_geonode_data
     GEONODE_GEODATABASE_PASSWORD=geonode
     
-    -DATABASE_URL=postgres://{{project_name}}:geonode@db:5432/{{project_name}}
+    -DATABASE_URL=postgis://{{project_name}}:geonode@db:5432/{{project_name}}
     -GEODATABASE_URL=postgis://{{project_name}}_data:geonode@db:5432/{{project_name}}_data
-    +DATABASE_URL=postgres://my_geonode:geonode@db:5432/my_geonode
+    +DATABASE_URL=postgis://my_geonode:geonode@db:5432/my_geonode
     +GEODATABASE_URL=postgis://my_geonode_data:geonode@db:5432/my_geonode_data
     DEFAULT_BACKEND_DATASTORE=datastore
     BROKER_URL=amqp://guest:guest@rabbitmq:5672/


### PR DESCRIPTION
PR to change URLs and references to Postgres and SQLite databases to PostGIS and Spatialite databases respectively, where appropriate. This change is part of the greater [GNIP 75 - Enable spatial data store for Django DB](https://github.com/GeoNode/geonode/issues/6079).