### PR TITLE
Update index.rst

### DIFF
--- a/install/basic/index.rst
+++ b/install/basic/index.rst
@@ -27,7 +27,7 @@ First Step: Deploy GeoNode on a local server (e.g.: http://localhost/)
 Ubuntu (18.0 +)
 ^^^^^^^^^^^^^^^
 
-.. note:: Recommended version 18.0.4 or higher.
+.. note:: Recommended version 18.0.4 (Bionic Beaver). 
 
 Packages Installation
 .....................


### PR DESCRIPTION
The versions of many dependencies (Django, gdal, pip, and python) in Ubuntu 20.04 Focal Fossa repositories are not compatible with this project (some are absent).

The changes to gdal 2.2.3+ and gdal 3.0.4+ may be entirely responsible.