### PR TITLE
added information explaining how to install PostgresQL on Ubuntu 18.0.4

### DIFF
--- a/install/advanced/project/index.rst
+++ b/install/advanced/project/index.rst
@@ -160,6 +160,121 @@ Make an instance out of the ``Django Template``
   mv manage_dev.sh.sample manage_dev.sh
   mv paver_dev.sh.sample paver_dev.sh
 
+Install and Configure the PostgreSQL Database System
+....................................................
+
+In this section we are going to install the ``PostgreSQL`` packages along with the ``PostGIS`` extension. Those steps must be done **only** if you don't have the DB already installed on your system.
+
+.. code-block:: shell
+
+  # Ubuntu 18.04
+  sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list'
+  sudo wget --no-check-certificate --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+  sudo apt update -y; sudo apt install -y postgresql-13 postgresql-13-postgis-3 postgresql-13-postgis-3-scripts postgresql-13 postgresql-client-13
+
+We now must create two databases, ``my_geonode`` and ``my_geonode_data``, belonging to the role ``my_geonode``.
+
+.. warning:: This is our default configuration.
+  You can use any database or role you need.
+  The connection parameters must be correctly configured on ``settings``, as we will see later in this section.
+
+Databases and Permissions
+.........................
+
+First, create the geonode user. GeoNode is going to use this user to access the database
+
+.. code-block:: shell
+
+  sudo service postgresql start
+  sudo -u postgres createuser -P my_geonode
+
+  # Use the password: geonode
+
+You will be prompted asked to set a password for the user. **Enter geonode as password**.
+
+.. warning:: This is a sample password used for the sake of simplicity. This password is very **weak** and should be changed in a production environment.
+
+Create database ``my_geonode`` and ``my_geonode_data`` with owner ``my_geonode``
+
+.. code-block:: shell
+
+  sudo -u postgres createdb -O my_geonode my_geonode
+  sudo -u postgres createdb -O my_geonode my_geonode_data
+
+Next let's create PostGIS extensions
+
+.. code-block:: shell
+
+  sudo -u postgres psql -d my_geonode -c 'CREATE EXTENSION postgis;'
+  sudo -u postgres psql -d my_geonode -c 'GRANT ALL ON geometry_columns TO PUBLIC;'
+  sudo -u postgres psql -d my_geonode -c 'GRANT ALL ON spatial_ref_sys TO PUBLIC;'
+  sudo -u postgres psql -d my_geonode -c 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO my_geonode;'
+
+  sudo -u postgres psql -d my_geonode_data -c 'CREATE EXTENSION postgis;'
+  sudo -u postgres psql -d my_geonode_data -c 'GRANT ALL ON geometry_columns TO PUBLIC;'
+  sudo -u postgres psql -d my_geonode_data -c 'GRANT ALL ON spatial_ref_sys TO PUBLIC;'
+  sudo -u postgres psql -d my_geonode_data -c 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO my_geonode;'
+
+Final step is to change user access policies for local connections in the file ``pg_hba.conf``
+
+.. code-block:: shell
+
+  sudo vim /etc/postgresql/13/main/pg_hba.conf
+
+Scroll down to the bottom of the document. We want to make local connection ``trusted`` for the default user.
+
+Make sure your configuration looks like the one below.
+
+.. code-block:: shell
+
+    ...
+    # DO NOT DISABLE!
+    # If you change this first entry you will need to make sure that the
+    # database superuser can access the database using some other method.
+    # Noninteractive access to all databases is required during automatic
+    # maintenance (custom daily cronjobs, replication, and similar tasks).
+    #
+    # Database administrative login by Unix domain socket
+    local   all             postgres                                trust
+
+    # TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+    # "local" is for Unix domain socket connections only
+    local   all             all                                     md5
+    # IPv4 local connections:
+    host    all             all             127.0.0.1/32            md5
+    # IPv6 local connections:
+    host    all             all             ::1/128                 md5
+    # Allow replication connections from localhost, by a user with the
+    # replication privilege.
+    local   replication     all                                     peer
+    host    replication     all             127.0.0.1/32            md5
+    host    replication     all             ::1/128                 md5
+
+.. warning:: If your ``PostgreSQL`` database resides on a **separate/remote machine**, you'll have to **allow** remote access to the databases in the ``/etc/postgresql/13/main/pg_hba.conf`` to the ``geonode`` user and tell PostgreSQL to **accept** non-local connections in your ``/etc/postgresql/13/main/postgresql.conf`` file
+
+Restart PostgreSQL to make the change effective.
+
+.. code-block:: shell
+
+  sudo service postgresql restart
+
+PostgreSQL is now ready. To test the configuration, try to connect to the ``geonode`` database as ``geonode`` role.
+
+.. code-block:: shell
+
+  psql -U postgres my_geonode
+  # This should not ask for any password
+
+  psql -U my_geonode my_geonode
+  # This should ask for the password geonode
+
+  # Repeat the test with geonode_data DB
+  psql -U postgres my_geonode_data
+  psql -U my_geonode my_geonode_data
+
+
+
 
 Run GeoNode Project for the first time in DEBUG Mode
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This commit adds the missing information about how to setup PostgresQL when running the installation on Ubuntu 18.04 manually. 

This information was provided in previous versions of the documentation but seems to have been left out of the current version. 