### PR TITLE
Remove empty pages

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -197,6 +197,11 @@ latex_documents = [
    'GeoNode Development Team', 'manual'),
 ]
 
+# remove empty pages
+latex_elements = {
+  'extraclassoptions': 'openany,oneside'
+}
+
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
 #latex_logo = None


### PR DESCRIPTION
Read the docs creates a PDF Version for generated docs. Unfortunately those pdf files contain a lot of empty pages. This added config will skip those