### PR TITLE
Update documentation about GeoServer admin password

### DIFF
--- a/install/basic/index.rst
+++ b/install/basic/index.rst
@@ -583,7 +583,7 @@ Update the passwords and keys on :guilabel:`.env` file
     
     # #################
 
-    .. warning:: **Be careful!** The env GEOSERVER_ADMIN_PASSWORD is not actually used to change the GeoServer admin password. You need to login on GeoServer UI and change it manually!
+.. warning:: **Be careful!** The env GEOSERVER_ADMIN_PASSWORD is not actually used to change the GeoServer admin password. You need to login on GeoServer UI and change it manually!
 
 [Optional] Update your SSH Certificates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/install/basic/index.rst
+++ b/install/basic/index.rst
@@ -583,6 +583,8 @@ Update the passwords and keys on :guilabel:`.env` file
     
     # #################
 
+    .. warning:: **Be careful!** The env GEOSERVER_ADMIN_PASSWORD is not actually used to change the GeoServer admin password. You need to login on GeoServer UI and change it manually!
+
 [Optional] Update your SSH Certificates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
I added a simple warning tab to notify users that the variable GEOSERVER_ADMIN_PASSWORD configured in **.env** is not actually used to change the GeoServer admin password. I edited only this part of documentation because it is the only part where GEOSERVER_ADMIN_PASSWORD is explicitly mentioned inside the **.env** file and this is the variable that is used by geoserverfixture to try to reset admin password without success.