### PR TITLE
update package pins in requirements #159

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,8 +1,9 @@
-sphinx==2.4.3
+sphinx==4.2.0
 sphinx-intl==2.0.1
-sphinx_rtd_theme==0.4.3
+sphinx_rtd_theme==0.5.2
 readthedocs-sphinx-ext==1.0.1
 m2r==0.2.1
 mistune==0.8.4
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.7.0
+docutils==0.16


### PR DESCRIPTION
This is an upgrade for three python packages, aimed at #159 and, more generally, updating Sphinx. Whether or not these packages are fully honored in read the docs may depend on how the RTD project is set up. One option is to also add a [config](https://docs.readthedocs.io/en/stable/config-file/v2.html) file in this repo that RTD can read from.