### PR TITLE
Update Ubuntu 20 rabbitmq installation to use cloudsmith.io

### DIFF
--- a/install/advanced/core/index.rst
+++ b/install/advanced/core/index.rst
@@ -1321,20 +1321,43 @@ Install and configure `"rabbitmq-server" <https://lindevs.com/install-rabbitmq-o
 
 **Install rabbitmq-server**
 
-Reference: `lindevs.com/install-rabbitmq-on-ubuntu/ <https://lindevs.com/install-rabbitmq-on-ubuntu/>`_
+Reference: `lindevs.com/install-rabbitmq-on-ubuntu/ <https://lindevs.com/install-rabbitmq-on-ubuntu/>`_ & `www.rabbitmq.com/install-debian.html/ <https://www.rabbitmq.com/install-debian.html#apt-cloudsmith/>`_
 
 .. code-block:: bash
 
-    sudo apt update && sudo apt upgrade && sudo apt install wget -y
+    sudo apt-get install curl gnupg apt-transport-https -y
+
+    ## Team RabbitMQ's main signing key
+    curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/com.rabbitmq.team.gpg > /dev/null
+    ## Cloudsmith: modern Erlang repository
+    curl -1sLf https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.cloudsmith.rabbitmq.E495BB49CC4BBE5B.gpg > /dev/null
+    ## Cloudsmith: RabbitMQ repository
+    curl -1sLf https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.cloudsmith.rabbitmq.9F4587F226208342.gpg > /dev/null
+	
+    ## Add apt repositories maintained by Team RabbitMQ
+    sudo tee /etc/apt/sources.list.d/rabbitmq.list <<EOF
+    ## Provides modern Erlang/OTP releases
+    ##
+    deb [signed-by=/usr/share/keyrings/io.cloudsmith.rabbitmq.E495BB49CC4BBE5B.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main
+    deb-src [signed-by=/usr/share/keyrings/io.cloudsmith.rabbitmq.E495BB49CC4BBE5B.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main
+	
+    ## Provides RabbitMQ
+    ##
+    deb [signed-by=/usr/share/keyrings/io.cloudsmith.rabbitmq.9F4587F226208342.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu focal main
+    deb-src [signed-by=/usr/share/keyrings/io.cloudsmith.rabbitmq.9F4587F226208342.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu focal main
     
-    # add the erlang repository
-    sudo add-apt-repository -y ppa:rabbitmq/rabbitmq-erlang
-
-    # add the rabbitmq repository
-    wget -qO - https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.deb.sh | sudo bash
-
-    # install rabbitmq
-    sudo apt install -y rabbitmq-server
+    ## Update package indices
+    sudo apt-get update -y
+	
+    ## Install Erlang packages
+    sudo apt-get install -y erlang-base \
+                        erlang-asn1 erlang-crypto erlang-eldap erlang-ftp erlang-inets \
+                        erlang-mnesia erlang-os-mon erlang-parsetools erlang-public-key \
+                        erlang-runtime-tools erlang-snmp erlang-ssl \
+                        erlang-syntax-tools erlang-tftp erlang-tools erlang-xmerl
+	
+    ## Install rabbitmq-server and its dependencies
+    sudo apt-get install rabbitmq-server -y --fix-missing
 
     # check the status (it should already be running)
     sudo systemctl status rabbitmq-server

--- a/install/advanced/core/index.rst
+++ b/install/advanced/core/index.rst
@@ -1335,7 +1335,7 @@ Reference: `lindevs.com/install-rabbitmq-on-ubuntu/ <https://lindevs.com/install
     curl -1sLf https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.cloudsmith.rabbitmq.9F4587F226208342.gpg > /dev/null
 	
     ## Add apt repositories maintained by Team RabbitMQ
-    sudo tee /etc/apt/sources.list.d/rabbitmq.list <<EOF
+    sudo vim /etc/apt/sources.list.d/rabbitmq.list
     ## Provides modern Erlang/OTP releases
     ##
     deb [signed-by=/usr/share/keyrings/io.cloudsmith.rabbitmq.E495BB49CC4BBE5B.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main

--- a/install/advanced/core/index.rst
+++ b/install/advanced/core/index.rst
@@ -1325,39 +1325,22 @@ Reference: `lindevs.com/install-rabbitmq-on-ubuntu/ <https://lindevs.com/install
 
 .. code-block:: bash
 
-    sudo apt-get install curl gnupg apt-transport-https -y
+    sudo apt install curl -y
 
-    ## Team RabbitMQ's main signing key
-    curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/com.rabbitmq.team.gpg > /dev/null
     ## Cloudsmith: modern Erlang repository
-    curl -1sLf https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.cloudsmith.rabbitmq.E495BB49CC4BBE5B.gpg > /dev/null
+    curl -1sLf 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/setup.deb.sh' | sudo -E bash
     ## Cloudsmith: RabbitMQ repository
-    curl -1sLf https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.cloudsmith.rabbitmq.9F4587F226208342.gpg > /dev/null
-	
-    ## Add apt repositories maintained by Team RabbitMQ
-    sudo vim /etc/apt/sources.list.d/rabbitmq.list
-    ## Provides modern Erlang/OTP releases
-    ##
-    deb [signed-by=/usr/share/keyrings/io.cloudsmith.rabbitmq.E495BB49CC4BBE5B.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main
-    deb-src [signed-by=/usr/share/keyrings/io.cloudsmith.rabbitmq.E495BB49CC4BBE5B.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main
-	
-    ## Provides RabbitMQ
-    ##
-    deb [signed-by=/usr/share/keyrings/io.cloudsmith.rabbitmq.9F4587F226208342.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu focal main
-    deb-src [signed-by=/usr/share/keyrings/io.cloudsmith.rabbitmq.9F4587F226208342.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu focal main
-    
-    ## Update package indices
-    sudo apt-get update -y
+    curl -1sLf 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/setup.deb.sh' | sudo -E bash
 	
     ## Install Erlang packages
-    sudo apt-get install -y erlang-base \
+    sudo apt install -y erlang-base \
                         erlang-asn1 erlang-crypto erlang-eldap erlang-ftp erlang-inets \
                         erlang-mnesia erlang-os-mon erlang-parsetools erlang-public-key \
                         erlang-runtime-tools erlang-snmp erlang-ssl \
                         erlang-syntax-tools erlang-tftp erlang-tools erlang-xmerl
 	
     ## Install rabbitmq-server and its dependencies
-    sudo apt-get install rabbitmq-server -y --fix-missing
+    sudo apt install rabbitmq-server -y --fix-missing
 
     # check the status (it should already be running)
     sudo systemctl status rabbitmq-server


### PR DESCRIPTION
I live in cuba, a USA forbidden country, so we (and other countries around the world) can't use the previously recommended site. So I used the official Installation guide and it works perfectly. Then I propose use it on the installations steps only, and keep the configuration as it is.
fix #182 