### PR TITLE
Geonode Core Advanced Step 6.3 keep .env variables

### DIFF
--- a/install/advanced/core/index.rst
+++ b/install/advanced/core/index.rst
@@ -1222,10 +1222,13 @@ In particular the steps to do are:
     .. code-block:: shell
 
         workon geonode
+	sudo su
         cd /opt/geonode
 
         # Update the GeoNode ip or hostname
-        sudo PYTHONWARNINGS=ignore VIRTUAL_ENV=$VIRTUAL_ENV DJANGO_SETTINGS_MODULE=geonode.local_settings GEONODE_ETC=/opt/geonode/geonode GEOSERVER_DATA_DIR=/opt/data/geoserver_data TOMCAT_SERVICE="service tomcat" APACHE_SERVICE="service nginx" geonode_updateip -l localhost -p www.example.org
+        PYTHONWARNINGS=ignore VIRTUAL_ENV=$VIRTUAL_ENV DJANGO_SETTINGS_MODULE=geonode.local_settings GEONODE_ETC=/opt/geonode/geonode GEOSERVER_DATA_DIR=/opt/data/geoserver_data TOMCAT_SERVICE="service tomcat9" APACHE_SERVICE="service nginx" geonode_updateip -l localhost -p www.example.org
+
+	exit
 
     4. Update the existing ``GeoNode`` links in order to hit the new hostname.
 


### PR DESCRIPTION
Added 'sudo su' after 'workon geonode' to keep .env variables.
fix #186