### PR TITLE
Install git

### DIFF
--- a/install/advanced/project/index.rst
+++ b/install/advanced/project/index.rst
@@ -73,6 +73,7 @@ First, we are going to install all the **system packages** needed for the GeoNod
   sudo apt install -y software-properties-common build-essential
   sudo apt install -y git unzip gcc zlib1g-dev libgeos-dev libproj-dev
   sudo apt install -y sqlite3 spatialite-bin libsqlite3-mod-spatialite
+  sudo apt install git
 
   # If the following does not work, you can skip it
   sudo apt install -y libgdal-dev


### PR DESCRIPTION
Install git prior to cloning the GeoNode repository. Following the official documentation in a clean Ubuntu 18.04LTS, when I try cloning the terminal asks to install Git.
![image](https://user-images.githubusercontent.com/23359514/148887732-309d4f41-e6c9-4719-b133-1bcfb435a2d6.png)
