### PR TITLE
Add documentation for the dump_thesaurus command

### DIFF
--- a/admin/index.rst
+++ b/admin/index.rst
@@ -16,7 +16,7 @@ It should be highlighted that the sections not covered in this guide are meant t
 GeoNode Management Commands
 ===========================
 
-Managemant commands are utility functions for GeoNode maintenance tasks. They are usually run from an SSH/bash shell on the server running GeoNode.
+Management commands are utility functions for GeoNode maintenance tasks. They are usually run from an SSH/bash shell on the server running GeoNode.
 Any call to python is prepended with a configuration parameter to indicate the GeoNode settings module to be used.
 
 .. code-block:: shell
@@ -62,7 +62,7 @@ GeoNode Async Signals
 
     async/index
 
-GeoNode add a thesaurus
+GeoNode Add a thesaurus
 =======================
 
 .. toctree::

--- a/admin/mgmt_commands/index.rst
+++ b/admin/mgmt_commands/index.rst
@@ -1684,6 +1684,12 @@ In this section we will provide a set of :guilabel:`shell` scripts which might b
 
 .. _createsuperuser:
 
+Thesaurus Import and Export
+===========================
+
+See :ref:`load_thesaurus` and :ref:`dump_thesaurus`.
+
+
 Create Users and Super Users
 ============================
 

--- a/admin/thesaurus/index.rst
+++ b/admin/thesaurus/index.rst
@@ -1,31 +1,27 @@
-Loading a thesaurus
-===================
+Introduction
+============
 
-There are 2 possible ways to upload a Thesaurus in geonode:
+GeoNode can import a thesaurus (or multiple thesauri) in order to index resources against subject terms or keywords.
+Thesauri can be managed manually in the admin panel, or imported as `SKOS RDF <https://www.w3.org/2004/02/skos/>`_ using
+either the admin panel or the command-line:
 
-- Admin panel
-- Django command-line
-- settings.py (deprecated)
+Upload via the Admin panel
+==========================
 
-
-Admin panel
-===========
-You can add a thesaurus into you GeoNode using the ``upload thesaurus`` available in the Admin panel
-
-Navigate to the thesaurus page in the admin panel ``http://<your_geonode_host>/admin/base/thesaurus``. On the top-right of the page a button named `Upload thesaurus` will be available:
+Navigate to the thesaurus page in the admin panel ``http://<your_geonode_host>/admin/base/thesaurus``. On the top-right of the page a button named :guilabel:`Upload thesaurus` will be available:
 
 .. figure:: img/thesaurus_admin_1.png
      :align: center
 
-After clicking on it, a simple form for the upload will be shown. In order to let the upload works, is required to choose an `RDF` file
+After clicking on it, a simple form for the upload will be shown which will allow you to select your desired RDF file:
 
 .. figure:: img/thesaurus_admin_2.png
      :align: center
 
-By clicking on `Upload CSV`, the system will load the thesaurus by assigning to it a `slugify` name based on the file name.
+By clicking on `Upload RDF`, the system will load the thesaurus and assign it a "slugified" name based on the file name.
 The name can be easily change later in the edit page.
 
-If everything goes fine, a successfull message will be shown:
+If everything goes fine, a success message will be shown:
 
 .. figure:: img/thesaurus_admin_success.png
      :align: center
@@ -35,10 +31,13 @@ Otherwise the UI will show the error message:
 .. figure:: img/thesaurus_admin_fail.png
      :align: center
 
-Command line
-================
 
-A thesaurus can be loaded into GeoNode by using the ``load_thesaurus`` command:
+.. _load_thesaurus:
+
+Import via the ``load_thesaurus`` command
+=========================================
+
+A thesaurus can also be loaded into GeoNode by using the ``load_thesaurus`` management command:
 
 .. code-block:: shell
 
@@ -48,7 +47,7 @@ A thesaurus can be loaded into GeoNode by using the ``load_thesaurus`` command:
     --name=NAME           Identifier name for the thesaurus in this GeoNode instance.
     --file=FILE           Full path to a thesaurus in RDF format.
 
-In order add the inspire-themes thesaurus into a geonode instance, download it as file ``inspire-theme.rdf``  with the command:
+For example, in order add the `INSPIRE Spatial Data Themes <https://www.eionet.europa.eu/gemet/en/inspire-themes/>`_ thesaurus into a GeoNode instance, download it as file ``inspire-theme.rdf``  with the command:
 
 .. code-block:: shell
 
@@ -70,7 +69,9 @@ If you only want to make sure that a thesaurus file will be properly parsed, giv
 
 Configure a thesaurus in GeoNode
 ================================
+
 Configuration from `Admin`
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After you loaded a thesaurus into GeoNode, it should be configured in the :guilabel:`Admin` panel.
 
@@ -85,15 +86,15 @@ Once you are on the Thesaurus lists, select one thesaurus to open the Edit page
 
 
 - ``identifier``: (mandatory string) the identifier you used in the ``load_thesaurus`` commands.
-- ``title``: (mandatory string) The title of the thesaurus, is ingested by the ``load_thesaurus`` command.
-- ``date``: (mandatory date) The Date of the thesaurus, is ingested by the ``load_thesaurus`` command.
-- ``description``: (mandatory string) The description of the thesaurus, is ingested by the ``load_thesaurus`` command.
-- ``slug``: (mandatory string) The slug of the thesaurus, is ingested by the ``load_thesaurus`` command.
-- ``about``: (optional string) The about of the thesaurus, is ingested by the ``load_thesaurus`` command.
-- ``card min``: (optional integer) Decide the minimun cardinality, default = 0
-- ``card max``: (optional integer) Decide the maximun cardinality, default = -1
-- ``facet``: (boolean) Decide if the thesaurus will be shown in the facet list. default: True
-- ``order``: (integer) Decide the listing order of the thesaurus in the facet list and in the metadta editor. default: 0, asc order from 0 to N
+- ``title``: (mandatory string) The title of the thesaurus, set initially by the ``load_thesaurus`` command.
+- ``date``: (mandatory date) The Date of the thesaurus, set initially by the ``load_thesaurus`` command.
+- ``description``: (mandatory string) The description of the thesaurus, set initially by the ``load_thesaurus`` command.
+- ``slug``: (mandatory string) The slug of the thesaurus, set initially by the ``load_thesaurus`` command.
+- ``about``: (optional string) The about of the thesaurus, set initially by the ``load_thesaurus`` command.
+- ``card min``: (optional integer) The minimum cardinality, default = 0
+- ``card max``: (optional integer) The maximum cardinality, default = -1
+- ``facet``: (boolean) Decide if the thesaurus will be shown in the facet list, default: True
+- ``order``: (integer) Decide the listing order of the thesaurus in the facet list and in the metadata editor, default: 0, asc order from 0 to N
 
 Cardinality:
 
@@ -111,9 +112,9 @@ After the setup, in `Editing Tools -> Metadata -> Wizard` the thesaurus block wi
 
      *The metadata interface with the Thesaurus enabled*
 
-================================
 
 Configuration via `settings.py`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning:: *Deprecated* The Thesaurus configuration via settings is deprecated, will be removed in the future.
 
@@ -138,9 +139,32 @@ Apply a thesaurus to a resource
 
 After you've finished the setup you should find a new input widget in each resource metadata wizard allowing you to choose a thesaurus for your resource.
 
-After applying a thesaurus to resources those should be listed in the filter section in GeoNodes resource list views.
+After applying a thesaurus to resources those should be listed in the filter section in GeoNode's resource list views:
 
 .. figure:: ./img/thesaurus_filter.png
     :align: center
     :width: 350px
     :alt: thesauarus
+
+
+.. _dump_thesaurus:
+
+Exporting a thesaurus as RDF via the ``dump_thesaurus`` command
+================================================================
+
+GeoNode thesauri can be exported as RDF using the ``dump_thesaurus`` command:
+
+.. code-block:: shell
+
+    python manage.py dump_thesaurus --help
+
+    -n NAME, --name NAME  Dump the thesaurus with the given name
+    -f FORMAT, --format FORMAT
+                          Format string supported by rdflib, e.g.: pretty-xml (default), json-ld, n3, nt, pretty-xml, trig, ttl, xml
+    --default-lang LANG   Default language code for untagged string literals
+
+    -l, --list            List available thesauri
+
+The ``-n|--name`` argument refers, like the ``load_thesaurus`` command, to the thesaurus's identifier in GeoNode, as opposed to its title.
+If uploaded via the admin interface this is derived automatically from its file name. Information about thesauri can be shown on the command-line
+using ``dump_thesaurus`` with just the ``-l|--list`` option.


### PR DESCRIPTION
Also some polishing and fixing of a few typos on the rest of the thesaurus documentation and the addition of a couple of references to the command docs from the mgmt_commands page.

This is associated with GeoNode/geonode#8702