### PR TITLE
Setting default java

### DIFF
--- a/install/advanced/core/index.rst
+++ b/install/advanced/core/index.rst
@@ -72,6 +72,9 @@ First, we are going to install all the **system packages** needed for the GeoNod
   # Install Openjdk
   sudo apt install openjdk-8-jdk-headless default-jdk-headless -y
   sudo update-java-alternatives --jre-headless --jre --set java-1.8.0-openjdk-amd64
+  
+  # If the update-alternatives command does not work, try below command and select the number coinciding with openjdk-8-jdk
+  sudo update-alternatives --config java
 
   # Verify GDAL version
   gdalinfo --version


### PR DESCRIPTION
The command  `sudo update-java-alternatives --jre-headless --jre --set java-1.8.0-openjdk-amd64` results in the following error in Ubuntu 20.04LTS terminal. Therefore as a workaround, I used this command 
```
update-alternatives: error: no alternatives for policytool
update-alternatives: error: no alternatives for policytool
```
Therefore, using the command `sudo update-alternatives --config java` provides options for selecting default java as shown below.
```
There are 2 choices for the alternative java (providing /usr/bin/java).

  Selection    Path                                            Priority   Status
------------------------------------------------------------
  0            /usr/lib/jvm/java-11-openjdk-amd64/bin/java      1111      auto mode
  1            /usr/lib/jvm/java-11-openjdk-amd64/bin/java      1111      manual mode
* 2            /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java   1081      manual mode
```
through which one can select the default one to use.