### PR TITLE
Docker GPG keys

### DIFF
--- a/install/advanced/core/docker/ubuntu.rst
+++ b/install/advanced/core/docker/ubuntu.rst
@@ -11,7 +11,8 @@ Docker Setup (First time only)
   sudo apt-get install -y git-core git-buildpackage debhelper devscripts
   sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
 
-  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  sudo mkdir -p /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 
   sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 

--- a/install/advanced/core/docker/ubuntu.rst
+++ b/install/advanced/core/docker/ubuntu.rst
@@ -14,7 +14,7 @@ Docker Setup (First time only)
   sudo mkdir -p /etc/apt/keyrings
   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 
-  sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
   sudo apt-get update -y
   sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose


### PR DESCRIPTION
According to the Ubuntu documentation, the use of apt-key is deprecated, except for the use of apt-key del in maintainer scripts to remove existing keys from the main key ring. Please refer to the below references for details.
* [Linux uprising article](https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html)
* [Unix stackexchange thread](https://unix.stackexchange.com/questions/332672/how-to-add-a-third-party-repo-and-key-in-debian/582853#582853)

Further, referring to [this docker documentation](https://docs.docker.com/engine/install/ubuntu/), it has changed from apt-key add to using **sudo gpg --dearmor -o** command