### PR TITLE
fix broken m2r dependency, fix wrong API description, added Example

### DIFF
--- a/devel/api/V2/schema/openapi.yml
+++ b/devel/api/V2/schema/openapi.yml
@@ -204,13 +204,6 @@ paths:
 
         Examples:
 
-        Update one dog:
-
-            PATCH /dogs/1/
-            {
-                'fur': 'white'
-            }
-
         Update many dogs by ID:
 
             PATCH /dogs/
@@ -259,7 +252,18 @@ paths:
           description: ''
     patch:
       operationId: datasets_partial_update_2
-      description: API endpoint that allows layers to be viewed or edited.
+      description: |-
+        API endpoint that allows layers to be viewed or edited.
+
+        Example:
+        
+        Update the metadata (e.g.'title', 'abstract',...) of a dataset:
+        
+            PATCH /dataset/{id}/
+            {
+              '{metadata_1_name}': '{metadata_1_value}',
+              '{metadata_n_name}': '{metadata_n_value'
+            }
       parameters:
       - in: path
         name: id

--- a/devel/api/integration/index.rst
+++ b/devel/api/integration/index.rst
@@ -290,7 +290,7 @@ Update individual metadata:
         }
         response = requests.patch(url, auth=auth, json=data)
     .. note::
-        It's allowed to pass new values for `bbox_polygon` but this isn't recommended because the bounding box is calculated according to the dataset's spatial data. So even if the `bbox_polygon` is updated, it's value will revert back to the actual bounding of the spatial data when any other field for dataset is updated.
+        `bbox_polygon` and `ll_bbox_polygon` are derived values which cannot be changed.
 Resource Delete
 ---------------
 

--- a/devel/api/integration/index.rst
+++ b/devel/api/integration/index.rst
@@ -533,3 +533,54 @@ The ``status_url`` property returns the URL to track kthe progress of the reques
 
 The operation will be completed once the ``status`` property is updated with the value ``finished``.
 
+Dataset Get Metadata 
+-----------------------------
+Get the metadata of uploaded datasets with:
+    - API: ``GET /api/v2/datasets/{id}``
+    - Status Code: ``200``
+
+    Example:
+
+    .. code-block:: shell
+
+        import requests
+        
+        DATASET_ID = "the dataset id"
+        url = f"https://master.demo.geonode.org/api/v2/datasets/{DATASET_ID}"
+        headers = {
+            'Authorization': 'Basic dXNlcjpwYXNzd29yZA=='
+        }
+        response = requests.request("GET", url, headers=headers)
+
+Dataset Update Metadata 
+-----------------------------
+
+Update individual metadata:
+    - API: ``PATCH /api/v2/datasets/{id}``
+    - Status Code: ``200``
+
+    Example:
+
+    This example changes the title, the bbox polygon, and the license of a dataset.
+
+    .. code-block:: shell
+
+        import requests
+
+        url = ROOT + "api/v2/datasets/" + DATASET_ID
+        auth = (LOGIN_NAME, LOGIN_PASSWORD)
+
+        data = {
+            "title": "a new title",
+            "bbox_polygon": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[0.0, 0.0], [0.0, 50.0], [50.0, 50.0], [50.0, 0.0], [0.0, 0.0]]
+                ],
+            },
+            "license": 4, 
+        }
+        response = requests.patch(url, auth=auth, json=data)
+
+
+

--- a/devel/api/integration/index.rst
+++ b/devel/api/integration/index.rst
@@ -157,6 +157,25 @@ Example:
     url = "https://master.demo.geonode.org/api/v2/resources/resource_types"
     response = requests.request("GET", url, headers=headers, data=payload)
 
+Dataset Get standardized Metadata
+-----------------------------
+Get the metadata of uploaded datasets with:
+    - API: ``GET /api/v2/datasets/{id}``
+    - Status Code: ``200``
+
+    Example:
+
+    .. code-block:: shell
+
+        import requests
+        
+        DATASET_ID = "the dataset id"
+        url = f"https://master.demo.geonode.org/api/v2/datasets/{DATASET_ID}"
+        headers = {
+            'Authorization': 'Basic dXNlcjpwYXNzd29yZA=='
+        }
+        response = requests.request("GET", url, headers=headers)
+
 Resource Upload
 ---------------
 
@@ -245,6 +264,36 @@ Example:
         ‘Authorization’: ‘Basic dXNlcjpwYXNzd29yZA==’
     }
     response = requests.request("PATCH", url, headers=headers, data=payload)
+
+Dataset Update Metadata 
+-----------------------------
+
+Update individual metadata:
+    - API: ``PATCH /api/v2/datasets/{id}``
+    - Status Code: ``200``
+
+    Example:
+
+    This example changes the title, the bbox polygon, and the license of a dataset.
+
+    .. code-block:: shell
+
+        import requests
+
+        url = ROOT + "api/v2/datasets/" + DATASET_ID
+        auth = (LOGIN_NAME, LOGIN_PASSWORD)
+
+        data = {
+            "title": "a new title",
+            "bbox_polygon": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[0.0, 0.0], [0.0, 50.0], [50.0, 50.0], [50.0, 0.0], [0.0, 0.0]]
+                ],
+            },
+            "license": 4, 
+        }
+        response = requests.patch(url, auth=auth, json=data)
 
 Resource Delete
 ---------------
@@ -532,55 +581,3 @@ The ``status_url`` property returns the URL to track kthe progress of the reques
 
 
 The operation will be completed once the ``status`` property is updated with the value ``finished``.
-
-Dataset Get Metadata 
------------------------------
-Get the metadata of uploaded datasets with:
-    - API: ``GET /api/v2/datasets/{id}``
-    - Status Code: ``200``
-
-    Example:
-
-    .. code-block:: shell
-
-        import requests
-        
-        DATASET_ID = "the dataset id"
-        url = f"https://master.demo.geonode.org/api/v2/datasets/{DATASET_ID}"
-        headers = {
-            'Authorization': 'Basic dXNlcjpwYXNzd29yZA=='
-        }
-        response = requests.request("GET", url, headers=headers)
-
-Dataset Update Metadata 
------------------------------
-
-Update individual metadata:
-    - API: ``PATCH /api/v2/datasets/{id}``
-    - Status Code: ``200``
-
-    Example:
-
-    This example changes the title, the bbox polygon, and the license of a dataset.
-
-    .. code-block:: shell
-
-        import requests
-
-        url = ROOT + "api/v2/datasets/" + DATASET_ID
-        auth = (LOGIN_NAME, LOGIN_PASSWORD)
-
-        data = {
-            "title": "a new title",
-            "bbox_polygon": {
-                "type": "Polygon",
-                "coordinates": [
-                    [[0.0, 0.0], [0.0, 50.0], [50.0, 50.0], [50.0, 0.0], [0.0, 0.0]]
-                ],
-            },
-            "license": 4, 
-        }
-        response = requests.patch(url, auth=auth, json=data)
-
-
-

--- a/devel/api/integration/index.rst
+++ b/devel/api/integration/index.rst
@@ -162,7 +162,8 @@ Dataset Get standardized Metadata
 Get the metadata of uploaded datasets with:
     - API: ``GET /api/v2/datasets/{id}``
     - Status Code: ``200``
-
+    .. note::
+        This is very similar to `GET /api/v2/resources` but provides additional metadata specifically for datasets like `featureinfo_custom_template` or `attribute_set`
     Example:
 
     .. code-block:: shell
@@ -274,7 +275,7 @@ Update individual metadata:
 
     Example:
 
-    This example changes the title, the bbox polygon, and the license of a dataset.
+    This example changes the title and the license of a dataset.
 
     .. code-block:: shell
 
@@ -285,16 +286,11 @@ Update individual metadata:
 
         data = {
             "title": "a new title",
-            "bbox_polygon": {
-                "type": "Polygon",
-                "coordinates": [
-                    [[0.0, 0.0], [0.0, 50.0], [50.0, 50.0], [50.0, 0.0], [0.0, 0.0]]
-                ],
-            },
             "license": 4, 
         }
         response = requests.patch(url, auth=auth, json=data)
-
+    .. note::
+        It's allowed to pass new values for `bbox_polygon` but this isn't recommended because the bounding box is calculated according to the dataset's spatial data. So even if the `bbox_polygon` is updated, it's value will revert back to the actual bounding of the spatial data when any other field for dataset is updated.
 Resource Delete
 ---------------
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -2,7 +2,7 @@ sphinx==4.2.0
 sphinx-intl==2.0.1
 sphinx_rtd_theme==0.5.2
 readthedocs-sphinx-ext==2.1.4
-m2r==0.2.1
+m2r2==0.3.2
 mistune==0.8.4
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.7.0


### PR DESCRIPTION
* The dependency [m2r](https://github.com/miyakogi/m2r) is not maintained since a long time ago and now leads to a conflict. I changed the m2r dependency to it's still maintained [m2r2 ](https://github.com/CrossNox/m2r2) fork.

* The description for the API endpoint `PATCH api/vs/datasets/{id}` was written under `PUT`. I fixed the location and added an example. (I couldn't get the part underneath the moved one to work so that might be also wrong. But I didn't have time to investigate that)

* I added examples for how to get metadata and how to update them.