### PR TITLE
Instructions for upgrading from 3.x to 4.x

### DIFF
--- a/admin/upgrade/3.2-to-3.3/index.rst
+++ b/admin/upgrade/3.2-to-3.3/index.rst
@@ -1,0 +1,113 @@
+.. _geonode-upgrade-3.2.x-3.3.x:
+
+Upgrade from 3.2.x / 3.3.x
+==========================
+
+1. Upgrade the dependencies
+2. Perform the ``migrations`` management command; in case some attribute is conflicting, remove it manually from the DB
+3. Proform the ``collectstatic`` management command
+
+Upgrade the instance dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Check the :ref:`install_dep` and :ref:`install_venv` sections in order to upgrade your Python environment.
+
+Also, make sure the code is ``Python 3.8`` compatible and that you switched and aligned the **source code** and the **requirements.txt** to the ``master`` branch.
+
+This must be done manually and with particular attention.
+
+.. code-block:: shell
+
+    workon <project environment>
+    cd <project_name>
+    pip install -r requirements.txt
+
+    cd /<full_path_to_geonode>
+
+    pip install pip --upgrade
+    pip install -r requirements.txt --upgrade
+    pip install -e . --upgrade
+    pip install pygdal=="`gdal-config --version`.*"
+
+    ./manage.sh collectstatic --noinput
+
+
+Run GeoNode migrations
+^^^^^^^^^^^^^^^^^^^^^^
+
+Activate your GeoNode virtualenv and set the env vars:
+
+.. code-block:: sql
+
+    . env/bin/Activate
+    export vars_210
+
+Here are the variables to export - update them to your environment settings:
+
+.. code-block:: shell
+
+    export DATABASE_URL=postgis://user:***@localhost:5432/dbname
+    export DEFAULT_BACKEND_DATASTORE=data
+    export GEODATABASE_URL=postgis://user:***@localhost:5432/geonode_data
+    export ALLOWED_HOSTS="['localhost', '192.168.100.10']"
+    export STATIC_ROOT=~/www/geonode/static/
+    export GEOSERVER_LOCATION=http://localhost:8080/geoserver/
+    export GEOSERVER_PUBLIC_LOCATION=http://localhost:8080/geoserver/
+    export GEOSERVER_ADMIN_PASSWORD=geoserver
+    export SESSION_EXPIRED_CONTROL_ENABLED=False
+
+
+Apply migrations and apply basic fixtures:
+
+.. code-block:: shell
+
+    ./manage.py migrate --fake-initial
+    paver sync
+
+
+.. note:: Incase of an error of :guilabel:`django.db.utils.ProgrammingError: column "colum-name" of relation "table-name" already exists` on running migrations, you can backup the field data with the following steps.
+
+.. code-block:: shell
+
+    ./manage.sh dbshell
+
+.. code-block:: sql
+
+    ALTER TABLE <table> ADD COLUMN <colum-name>_bkp varchar;
+    UPDATE <table> SET <colum-name>_bkp = colum-name;
+    ALTER TABLE <table> DROP COLUMN <colum-name>;
+
+    \q
+
+Run migration then:
+
+.. code-block:: shell
+
+    ./manage.sh dbshell
+
+.. code-block:: sql
+
+    UPDATE <table> SET <colum-name> = <colum-name>_bkp;
+    ALTER TABLE <table> DROP COLUMN <colum-name>_bkp;
+
+    \q
+
+
+Create superuser
+^^^^^^^^^^^^^^^^
+
+To create a superuser you should drop the following constraints (they can be re-enabled if needed):
+
+.. code-block:: sql
+
+    alter table people_profile alter column last_login drop not null;
+
+.. code-block:: shell
+
+    ./manage createsuperuser
+
+
+Update Templates
+^^^^^^^^^^^^^^^^
+
+Update available templates to use {% load static %} instead of {% load staticfiles %}

--- a/admin/upgrade/3.x-to-4.x/index.rst
+++ b/admin/upgrade/3.x-to-4.x/index.rst
@@ -23,7 +23,9 @@ With the following command, we will download the new version of GeoNode from the
 
 ::
 
-    https://github.com/GeoNode/geonode.git -b 4x
+    https://github.com/GeoNode/geonode.git -b <branch-or-tag>
+
+**Note:** Replace <branch-or-tag> with the appropriate branch or tag for the version you wish to install.
 
 It is recommended to do this in a separate directory to keep the previous version intact in case of need.
 
@@ -46,7 +48,7 @@ Run the following command in the directory where the current GeoNode is deployed
 
 ::
 
-    docker-compose down
+    docker compose down
 
 3. Modify the GeoNode .env File
 -------------------------------
@@ -66,7 +68,7 @@ Once you have made the necessary changes to the ``.env`` file, run the following
 
 ::
 
-    docker-compose up -d
+    docker compose up -d
 
 Possible Issues
 ===============

--- a/admin/upgrade/3.x-to-4.x/index.rst
+++ b/admin/upgrade/3.x-to-4.x/index.rst
@@ -1,0 +1,143 @@
+.. _geonode-upgrade-3.x-4.x:
+
+========================================
+Upgrade Process from GeoNode 3.x to 4.x
+========================================
+
+The purpose of this document is to detail the process that we will implement to upgrade GeoNode from version 3.x to version 4.x. This document is proposed to ensure that the upgrade process is efficient and understandable for everyone.
+
+The objective of this document is for everyone to understand the processes and steps necessary to carry out the migration.
+
+Table of Contents
+
+* Migration Procedure
+* Possible Issues
+
+Version Migration Procedure
+===========================
+
+1. Download the New Version
+---------------------------
+
+With the following command, we will download the new version of GeoNode from the official source or the corresponding repository:
+
+::
+
+    https://github.com/GeoNode/geonode.git -b 4x
+
+It is recommended to do this in a separate directory to keep the previous version intact in case of need.
+
+* Directory of the previous version:
+
+::
+
+    C:\Users\berna\geonode3>
+
+* Directory of the new version:
+
+::
+
+    C:\Users\berna\geonode4>
+
+2. Stop the Current GeoNode
+---------------------------
+
+Run the following command in the directory where the current GeoNode is deployed to stop the associated Docker containers:
+
+::
+
+    docker-compose down
+
+3. Modify the GeoNode .env File
+-------------------------------
+
+Open the ``.env`` file of the new GeoNode in a text editor:
+
+::
+
+    nano .env
+
+Adjust the environment variables to match the configuration of the previous GeoNode version. This may include variables related to the database, URLs, ports, etc.
+
+The following code is an example environment setup. Please replace the placeholder values with the actual data specific to your system:
+
+::
+
+    # ################
+    # backend
+    # ################
+    POSTGRES_USER=postgres_user
+    POSTGRES_PASSWORD=postgres_password
+    GEONODE_DATABASE=geonode_db
+    GEONODE_DATABASE_PASSWORD=geonode_password
+    GEONODE_GEODATABASE=geonode_data_db
+    GEONODE_GEODATABASE_PASSWORD=geonode_data_password
+    GEONODE_DATABASE_SCHEMA=public
+    GEONODE_GEODATABASE_SCHEMA=public
+    DATABASE_HOST=database_host
+    DATABASE_PORT=5432
+    DATABASE_URL=postgis://geonode:geonode_password@db:5432/geonode_db
+    GEODATABASE_URL=postgis://geonode_data:geonode_data_password@db:5432/geonode_data_db
+    GEONODE_DB_CONN_MAX_AGE=0
+    GEONODE_DB_CONN_TOUT=5
+    DEFAULT_BACKEND_DATASTORE=datastore
+    BROKER_URL=amqp://guest:guest@localhost:5672/
+    CELERY_BEAT_SCHEDULER=celery.beat.PersistentScheduler
+    ASYNC_SIGNALS=True
+
+    SITEURL=https://site_url/
+
+    ALLOWED_HOSTS=['django', '*']
+
+    # Data Uploader
+    DEFAULT_BACKEND_UPLOADER=geonode.importer
+    TIME_ENABLED=True
+    MOSAIC_ENABLED=False
+    HAYSTACK_SEARCH=False
+    HAYSTACK_ENGINE_URL=http://elasticsearch:9200/
+    HAYSTACK_ENGINE_INDEX_NAME=haystack
+    HAYSTACK_SEARCH_RESULTS_PER_PAGE=200
+
+4. Start the GeoNode Containers
+-------------------------------
+
+Once you have made the necessary changes to the ``.env`` file, run the following command to start the GeoNode containers in the new version:
+
+::
+
+    docker-compose up -d
+
+Possible Issues
+===============
+
+The version upgrade of GeoNode also involves changes in some of its components, which can generate various issues. Below, we list some common problems and their possible solutions:
+
+PostgreSQL Container in Constant Restart
+----------------------------------------
+
+**Logs:**
+
+::
+
+    2024-02-21 18:06:14.056 UTC [1] FATAL:  database files are incompatible with server
+
+    2024-02-21 18:06:14.056 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 13, which is not compatible with this version 15.4.</strong>
+
+**Cause:** The PostgreSQL version of the original GeoNode was lower than the current one.
+
+**Solution:** Downgrade the PostgreSQL version to match the previously installed version in the GeoNode ``docker-compose.yml`` file.
+
+Nginx Container in Constant Restart
+-----------------------------------
+
+**Logs:**
+
+::
+
+    2024/02/21 18:11:49 [emerg] 1#1: host not found in "$HTTP_PORT" of the "listen" directive in /etc/nginx/nginx.conf:25
+
+    nginx: [emerg] host not found in "$HTTP_PORT" of the "listen" directive in /etc/nginx/nginx.conf:25
+
+**Cause:** Nginx is having issues replacing the port variables from the ``nginx.conf.envsubst`` file.
+
+**Solution:** Manually replace those variables with the corresponding ports once in the ``nginx.conf.envsubst`` file. After this, Nginx should work correctly and replace the variables normally in the future.

--- a/admin/upgrade/3.x-to-4.x/index.rst
+++ b/admin/upgrade/3.x-to-4.x/index.rst
@@ -4,7 +4,7 @@
 Upgrade Process from GeoNode 3.x to 4.x
 ========================================
 
-The purpose of this document is to detail the process that we will implement to upgrade GeoNode from version 3.x to version 4.x. This document is proposed to ensure that the upgrade process is efficient and understandable for everyone.
+The purpose of this document is to detail the process that we will implement to upgrade GeoNode from version 3.x to version 4.x. This document is proposed to ensure that the upgrade process is efficient and understandable for everyone. It is important to note that this guide is specifically for a GeoNode installation running on Docker.
 
 The objective of this document is for everyone to understand the processes and steps necessary to carry out the migration.
 
@@ -31,13 +31,13 @@ It is recommended to do this in a separate directory to keep the previous versio
 
 ::
 
-    C:\Users\berna\geonode3>
+    my/work/dir/geonode3
 
 * Directory of the new version:
 
 ::
 
-    C:\Users\berna\geonode4>
+    my/work/dir/geonode4
 
 2. Stop the Current GeoNode
 ---------------------------
@@ -58,45 +58,6 @@ Open the ``.env`` file of the new GeoNode in a text editor:
     nano .env
 
 Adjust the environment variables to match the configuration of the previous GeoNode version. This may include variables related to the database, URLs, ports, etc.
-
-The following code is an example environment setup. Please replace the placeholder values with the actual data specific to your system:
-
-::
-
-    # ################
-    # backend
-    # ################
-    POSTGRES_USER=postgres_user
-    POSTGRES_PASSWORD=postgres_password
-    GEONODE_DATABASE=geonode_db
-    GEONODE_DATABASE_PASSWORD=geonode_password
-    GEONODE_GEODATABASE=geonode_data_db
-    GEONODE_GEODATABASE_PASSWORD=geonode_data_password
-    GEONODE_DATABASE_SCHEMA=public
-    GEONODE_GEODATABASE_SCHEMA=public
-    DATABASE_HOST=database_host
-    DATABASE_PORT=5432
-    DATABASE_URL=postgis://geonode:geonode_password@db:5432/geonode_db
-    GEODATABASE_URL=postgis://geonode_data:geonode_data_password@db:5432/geonode_data_db
-    GEONODE_DB_CONN_MAX_AGE=0
-    GEONODE_DB_CONN_TOUT=5
-    DEFAULT_BACKEND_DATASTORE=datastore
-    BROKER_URL=amqp://guest:guest@localhost:5672/
-    CELERY_BEAT_SCHEDULER=celery.beat.PersistentScheduler
-    ASYNC_SIGNALS=True
-
-    SITEURL=https://site_url/
-
-    ALLOWED_HOSTS=['django', '*']
-
-    # Data Uploader
-    DEFAULT_BACKEND_UPLOADER=geonode.importer
-    TIME_ENABLED=True
-    MOSAIC_ENABLED=False
-    HAYSTACK_SEARCH=False
-    HAYSTACK_ENGINE_URL=http://elasticsearch:9200/
-    HAYSTACK_ENGINE_INDEX_NAME=haystack
-    HAYSTACK_SEARCH_RESULTS_PER_PAGE=200
 
 4. Start the GeoNode Containers
 -------------------------------

--- a/admin/upgrade/index.rst
+++ b/admin/upgrade/index.rst
@@ -1,111 +1,13 @@
-Upgrade from 3.2.x / 3.3.x
-=========================
+===============
+Upgrade GeoNode
+===============
 
-1. Upgrade the dependencies
-2. Perform the ``migrations`` management command; in case some attribute is conflicting, remove it manually from the DB
-3. Proform the ``collectstatic`` management command
+.. toctree::
+    :maxdepth: 3
 
-Upgrade the instance dependencies
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3.2-to-3.3/index
 
-Check the :ref:`install_dep` and :ref:`install_venv` sections in order to upgrade your Python environment.
+.. toctree::
+    :maxdepth: 3
 
-Also, make sure the code is ``Python 3.8`` compatible and that you switched and aligned the **source code** and the **requirements.txt** to the ``master`` branch.
-
-This must be done manually and with particular attention.
-
-.. code-block:: shell
-
-    workon <project environment>
-    cd <project_name>
-    pip install -r requirements.txt
-
-    cd /<full_path_to_geonode>
-
-    pip install pip --upgrade
-    pip install -r requirements.txt --upgrade
-    pip install -e . --upgrade
-    pip install pygdal=="`gdal-config --version`.*"
-
-    ./manage.sh collectstatic --noinput
-
-
-Run GeoNode migrations
-^^^^^^^^^^^^^^^^^^^^^^
-
-Activate your GeoNode virtualenv and set the env vars:
-
-.. code-block:: sql
-
-    . env/bin/Activate
-    export vars_210
-
-Here are the variables to export - update them to your environment settings:
-
-.. code-block:: shell
-
-    export DATABASE_URL=postgis://user:***@localhost:5432/dbname
-    export DEFAULT_BACKEND_DATASTORE=data
-    export GEODATABASE_URL=postgis://user:***@localhost:5432/geonode_data
-    export ALLOWED_HOSTS="['localhost', '192.168.100.10']"
-    export STATIC_ROOT=~/www/geonode/static/
-    export GEOSERVER_LOCATION=http://localhost:8080/geoserver/
-    export GEOSERVER_PUBLIC_LOCATION=http://localhost:8080/geoserver/
-    export GEOSERVER_ADMIN_PASSWORD=geoserver
-    export SESSION_EXPIRED_CONTROL_ENABLED=False
-
-
-Apply migrations and apply basic fixtures:
-
-.. code-block:: shell
-
-    ./manage.py migrate --fake-initial
-    paver sync
-
-
-.. note:: Incase of an error of :guilabel:`django.db.utils.ProgrammingError: column "colum-name" of relation "table-name" already exists` on running migrations, you can backup the field data with the following steps.
-
-.. code-block:: shell
-
-    ./manage.sh dbshell
-
-.. code-block:: sql
-
-    ALTER TABLE <table> ADD COLUMN <colum-name>_bkp varchar;
-    UPDATE <table> SET <colum-name>_bkp = colum-name;
-    ALTER TABLE <table> DROP COLUMN <colum-name>;
-
-    \q
-
-Run migration then:
-
-.. code-block:: shell
-
-    ./manage.sh dbshell
-
-.. code-block:: sql
-
-    UPDATE <table> SET <colum-name> = <colum-name>_bkp;
-    ALTER TABLE <table> DROP COLUMN <colum-name>_bkp;
-
-    \q
-
-
-Create superuser
-^^^^^^^^^^^^^^^^
-
-To create a superuser you should drop the following constraints (they can be re-enabled if needed):
-
-.. code-block:: sql
-
-    alter table people_profile alter column last_login drop not null;
-
-.. code-block:: shell
-
-    ./manage createsuperuser
-
-
-Update Templates
-^^^^^^^^^^^^^^^^
-
-Update available templates to use {% load static %} instead of {% load staticfiles %}
+    3.x-to-4.x/index


### PR DESCRIPTION
The PR includes a guide to upgrade from geonode 3.x to 4.x
It also has modifications to the index where documentation about the upgrades is compiled.

![image](https://github.com/GeoNode/documentation/assets/87376859/3736053f-8c91-404c-8867-512fea1ff768)

@anthieni @herver1971 