### PR TITLE
Update demo link to point to stable build

### DIFF
--- a/start/index.rst
+++ b/start/index.rst
@@ -109,7 +109,7 @@ Online Demo
     
     See the section :ref:`get_in_touch` for details.
 
-A live demo of the latest stable build is available at http://master.demo.geonode.org/.
+A live demo of the latest stable build is available at http://stable.demo.geonode.org/.
 
   .. figure:: img/online_demo-001.png
         :align: center


### PR DESCRIPTION
The current link, seems to be still pointing to a discontinued end point:
![2025-05-19_00-12](https://github.com/user-attachments/assets/d9e67cd6-5944-4bfa-a85f-a7856b72becf)
![image](https://github.com/user-attachments/assets/e23fb1cc-58b5-4cc9-87bc-da555d2b6609)

It is now updated to the correct end point:
![image](https://github.com/user-attachments/assets/3226e2b3-4bb0-4ba6-ad7e-bf7d0c398a5b)

