### PR TITLE
fix: correct SSL configuration instructions in basic installation

### DIFF
--- a/install/basic/index.rst
+++ b/install/basic/index.rst
@@ -236,11 +236,11 @@ If for some reason you are not able to reach the server on the :guilabel:`HTTPS`
       rm nginx.https.enabled.conf
       ln -s nginx.https.available.conf nginx.https.enabled.conf
 
-4. Inspect the ``nginx.https.enabled.conf`` contents
+4. Inspect the ``nginx.https.available.conf`` contents
 
     .. code-block:: shell
 
-      nano nginx.https.enabled.conf
+      nano nginx.https.available.conf
 
     Make sure the contents match the following
 
@@ -340,6 +340,10 @@ In production deployment mode, GeoNode uses by default :guilabel:`Let's Encrypt`
 
 You may want to provide your own certificates to GeoNode
 
+.. note::
+
+   **Important**: When making SSL-related configuration changes, always edit ``nginx.https.available.conf`` (the actual configuration file), not ``nginx.https.enabled.conf`` (which is a symlink). This ensures your changes are persistent and properly applied.
+
 .. code-block:: shell
 
     docker exec -it nginx4my_geonode_geonode sh -c 'mkdir /geonode-certificates/my_geonode'
@@ -357,7 +361,7 @@ You may want to provide your own certificates to GeoNode
     docker-compose exec geonode sh
     apk add vim
 
-    vim nginx.https.enabled.conf
+    vim nginx.https.available.conf
 
 
 .. code-block:: diff


### PR DESCRIPTION
This PR updates the GeoNode Basic Installation guide to correct SSL configuration instructions.
### Change Introduced
- [x] Corrected the SSL configuration step to ensure users edit `nginx.https.available.conf` instead of `nginx.https.enabled.conf` (symlink).

- `Troubleshooting` section

<img width="719" height="250" alt="image" src="https://github.com/user-attachments/assets/76b676e4-344a-404b-a7e1-3436ec8fc104" />

- `Configure your SSL Certificates` section

<img width="240" height="83" alt="image" src="https://github.com/user-attachments/assets/05a7fd39-ef62-40da-9daa-be539df08271" />

- [x] Added a `Note` block clarifying the difference between the two files to prevent misconfiguration and ensure changes persist. 
<img width="734" height="282" alt="image" src="https://github.com/user-attachments/assets/40fa0635-15f7-4e62-ac7e-29a209f1a6ca" />
